### PR TITLE
Refactor resources copying to per-package approach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "camino"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -36,24 +36,30 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -67,33 +73,33 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -102,20 +108,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -124,18 +131,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -144,6 +151,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/README.md
+++ b/README.md
@@ -11,15 +11,24 @@ See the example below:
 [package.metadata.packager]
 product_name = "Robrix"
 
+[package.metadata.packager.macos]
+## You can use `-` as the value for `signing_identity`,
+## if you just want to test the packaging on macOS without signing the app.
+signature_identity = "-"
 ...
 
 ## This runs just one time before packaging starts; thus, it is used
 ## mostly just to handle resources and target-agnostic stuff.
-before-packaging-command = """
-robius-packaging-commands before-packaging \
-    --binary-name robrix \
-    --path-to-binary ./target/release/robrix
-"""
+##
+## Note: if your project is a Makepad app, you don't need to specify this, because
+## before-each-package-command will automatically copy the app's resources
+## to the target directory, so you can just use that command for other you want to do
+## before packaging.
+# before-packaging-command = """
+# robius-packaging-commands before-packaging \
+#     --binary-name robrix \
+#     --path-to-binary ./target/release/robrix
+# """
 
 ...
 
@@ -30,6 +39,17 @@ robius-packaging-commands before-each-package \
     --binary-name robrix \
     --path-to-binary ./target/release/robrix
 """
+
+## Note: for now, if you are using Makepad apps, you need to add some additional configuration to your `Cargo.toml` file.
+resources = [
+    { src = "./dist/resources/makepad_widgets", target = "makepad_widgets" },
+    { src = "./dist/resources/makepad_fonts_chinese_bold", target = "makepad_fonts_chinese_bold" },
+    { src = "./dist/resources/makepad_fonts_chinese_bold_2", target = "makepad_fonts_chinese_bold_2" },
+    { src = "./dist/resources/makepad_fonts_chinese_regular", target = "makepad_fonts_chinese_regular" },
+    { src = "./dist/resources/makepad_fonts_chinese_regular_2", target = "makepad_fonts_chinese_regular_2" },
+    { src = "./dist/resources/makepad_fonts_emoji", target = "makepad_fonts_emoji" },
+    { src = "./dist/resources/robrix", target = "robrix" },
+]
 ```
 
 Once you have this package metadata fully completed in your app crate's `Cargo.toml`,

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,11 @@ fn before_each_package<P: AsRef<Path>>(
     }
 
     // If this is a Makepad app, copy Makepad-specific resources
-    if is_makepad_app() {
+    let should_copy_makepad_resources = match FORCE_MAKEPAD.get() {
+        Some(forced) => forced,
+        None => is_makepad_app(),
+    };
+    if should_copy_makepad_resources {
         copy_makepad_resources(&dist_resources_dir)?;
     }
     println!("All resources copied successfully to: {}", dist_resources_dir.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,7 @@ fn main() -> std::io::Result<()> {
 ///
 /// ## Functionality
 /// 1. Creates a directory for the resources to be packaged, which is currently `./dist/resources/`.
-/// 2. If a makepad app is being built, locates and copies in makepad-specific resource files.
-/// 3. Recursively copies the app-specific `./resources` directory to `./dist/resources/<main-binary-name>/`.
+/// 2. Recursively copies the app-specific `./resources` directory to `./dist/resources/<main-binary-name>/`.
 fn before_packaging(_host_os: &str, main_binary_name: &str) -> std::io::Result<()> {
     let cwd = std::env::current_dir()?;
     let dist_resources_dir = cwd.join("dist").join("resources");
@@ -147,25 +146,15 @@ fn before_each_package<P: AsRef<Path>>(
     main_binary_name: &str,
     path_to_binary: P,
 ) -> std::io::Result<()> {
-    let cwd = std::env::current_dir()?;
-    let dist_resources_dir = cwd.join("dist").join("resources");
-    fs::create_dir_all(&dist_resources_dir)?;
-
-    {
-        let app_resources_dest = dist_resources_dir.join(main_binary_name).join("resources");
-        let app_resources_src = cwd.join("resources");
-        println!("Copying app-specific resources...\n  --> From: {}\n      to:   {}", app_resources_src.display(), app_resources_dest.display());
-        copy_recursively(&app_resources_src, &app_resources_dest)?;
-        println!("  --> Done!");
-    }
-
     // The `CARGO_PACKAGER_FORMAT` environment variable is required.
     let format = std::env::var("CARGO_PACKAGER_FORMAT")
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     let package_format = format.as_str();
     println!("Running before-each-package-command for {package_format:?}");
-    let _ = match package_format         {
+
+    // First run compilation - only copy resources if compilation succeeds
+    let compilation_result = match package_format {
         "app" | "dmg" => before_each_package_macos(   package_format, host_os, &main_binary_name, &path_to_binary),
         "deb"         => before_each_package_deb(     package_format, host_os, &main_binary_name, &path_to_binary),
         "appimage"    => before_each_package_appimage(package_format, host_os, &main_binary_name, &path_to_binary),
@@ -176,8 +165,33 @@ fn before_each_package<P: AsRef<Path>>(
             format!("Unknown/unsupported package format {_other:?}"),
         )),
     };
-    copy_makepad_resources(&dist_resources_dir)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+
+    // Only proceed with resource copying if compilation succeeded
+    compilation_result?;
+
+    let cwd = std::env::current_dir()?;
+    let dist_resources_dir = cwd.join("dist").join("resources");
+
+    // Clear/delete existing resources directory to ensure no stale files
+    if dist_resources_dir.exists() {
+        fs::remove_dir_all(&dist_resources_dir)?;
+    }
+    fs::create_dir_all(&dist_resources_dir)?;
+
+    {
+        let app_resources_dest = dist_resources_dir.join(main_binary_name).join("resources");
+        let app_resources_src = cwd.join("resources");
+        println!("Copying app-specific resources...\n  --> From: {}\n      to:   {}", app_resources_src.display(), app_resources_dest.display());
+        copy_recursively(&app_resources_src, &app_resources_dest)?;
+        println!("  --> Done!");
+    }
+
+    // If this is a Makepad app, copy Makepad-specific resources
+    if is_makepad_app() {
+        copy_makepad_resources(&dist_resources_dir)?;
+    }
+    println!("All resources copied successfully to: {}", dist_resources_dir.display());
+    Ok(())
 }
 
 

--- a/src/makepad.rs
+++ b/src/makepad.rs
@@ -1,4 +1,5 @@
-use std::{path::Path, sync::OnceLock};
+use std::{collections::HashMap, fs, path::{Path, PathBuf}, sync::OnceLock};
+
 use cargo_metadata::MetadataCommand;
 
 pub(crate) static FORCE_MAKEPAD: OnceLock<bool> = OnceLock::new();
@@ -48,6 +49,32 @@ pub(crate) fn is_makepad_app() -> bool {
     })
 }
 
+pub(crate) fn get_makepad_resources_paths() -> HashMap<String, PathBuf> {
+    let paths_dir = PathBuf::from("target/release/");
+    fs::read_dir(&paths_dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+
+            if !path.is_file() {
+                return None;
+            }
+
+            let filename = path.file_name()?.to_str()?;
+
+            let package_name = filename
+                .strip_prefix("makepad-")?
+                .strip_suffix(".path")?;
+
+            let content = fs::read_to_string(&path).ok()?;
+            let resources_dir_path = PathBuf::from(content.trim());
+            let resources_dir_name = format!("makepad_{}", package_name.replace('-', "_"));
+            Some((resources_dir_name, resources_dir_path))
+        })
+        .collect()
+}
 
 /// Recursively copies the Makepad-specific resource files.
 ///
@@ -58,40 +85,24 @@ pub(crate) fn copy_makepad_resources<P>(dist_resources_dir: P) -> std::io::Resul
 where
     P: AsRef<Path>
 {
-    let makepad_widgets_resources_dest = dist_resources_dir.as_ref()
-        .join("makepad_widgets")
-        .join("resources");
-    let makepad_widgets_resources_src = {
-        let cargo_metadata = MetadataCommand::new()
-            .exec()
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let makepad_resources_paths = get_makepad_resources_paths();
+    if makepad_resources_paths.is_empty() {
+        // The user did not add the makepad-widgets dependency, but forced the --force-makepad flag.
+        println!("No Makepad resources found. Skipping copy.");
+        return Ok(());
+    }
 
-        let makepad_widgets_package_res = cargo_metadata
-            .packages
-            .iter()
-            .find(|package| package.name == "makepad-widgets")
-            .ok_or_else(|| std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "makepad-widgets package not found"
-            ));
+    for (resources_dir_name, resources_dir_path) in makepad_resources_paths {
+        let source_path = resources_dir_path.join("resources");
 
-        let _ = IS_MAKEPAD_APP.set(makepad_widgets_package_res.is_ok());
+        let makepad_widgets_resources_dest = dist_resources_dir.as_ref()
+            .join(resources_dir_name)
+            .join("resources");
 
-        makepad_widgets_package_res?
-            .manifest_path
-            .parent()
-            .ok_or_else(|| std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "makepad-widgets package manifest path not found"),
-            )?
-            .join("resources")
-    };
-
-    println!("Copying makepad-widgets resources...\n  --> From: {}\n      to:   {}",
-        makepad_widgets_resources_src.as_std_path().display(),
-        makepad_widgets_resources_dest.display(),
-    );
-    super::copy_recursively(&makepad_widgets_resources_src, &makepad_widgets_resources_dest)?;
+        if source_path.exists() {
+            super::copy_recursively(&source_path, &makepad_widgets_resources_dest)?;
+        }
+    }
     println!("  --> Done!");
     Ok(())
 }

--- a/src/makepad.rs
+++ b/src/makepad.rs
@@ -87,11 +87,10 @@ where
 {
     let makepad_resources_paths = get_makepad_resources_paths();
     if makepad_resources_paths.is_empty() {
-        // The user did not add the makepad-widgets dependency, but forced the --force-makepad flag.
-        println!("No Makepad resources found. Skipping copy.");
-        return Ok(());
+        // This situation can happen if the user use local Makepad repository and deletes the all `makepad-*.path` files.
+        return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "No Makepad resources found"));
     }
-
+    println!("Copying Makepad resources...");
     for (resources_dir_name, resources_dir_path) in makepad_resources_paths {
         let source_path = resources_dir_path.join("resources");
 
@@ -100,9 +99,9 @@ where
             .join("resources");
 
         if source_path.exists() {
+            println!("--> From: {}\n      to:   {}", source_path.display(), makepad_widgets_resources_dest.display());
             super::copy_recursively(&source_path, &makepad_widgets_resources_dest)?;
         }
     }
-    println!("  --> Done!");
     Ok(())
 }

--- a/src/makepad.rs
+++ b/src/makepad.rs
@@ -88,7 +88,10 @@ where
     let makepad_resources_paths = get_makepad_resources_paths();
     if makepad_resources_paths.is_empty() {
         // This situation can happen if the user use local Makepad repository and deletes the all `makepad-*.path` files.
-        return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "No Makepad resources found"));
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Missing resource paths: no `.path` files found in the Makepad build directory (./target/release/)",
+        ));
     }
     println!("Copying Makepad resources...");
     for (resources_dir_name, resources_dir_path) in makepad_resources_paths {


### PR DESCRIPTION
  - Move app resources copying from before_packaging to before_each_package.
  - Update makepad resources handling to support multiple packages.
  - Add dynamic makepad resources path detection using .path files.
  - Update dependencies to latest versions.