### PR TITLE
Support workspace target dir for makepad resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "robius-packaging-commands"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo_metadata",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "robius-packaging-commands"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -6,8 +6,37 @@
 A multi-platform companion tool to help package your Rust app when using `cargo-packager`.
 
 ## Quick example of usage
+### Workspace example (app crate is not workspace root)
+In a workspace, you can run `cargo packager` from the app crate directory. The tool will use the
+current directory for `./resources` and `./dist`, and use `--path-to-binary` to locate the target dir.
+
+```toml
+[package.metadata.packager]
+product_name = "Robrix"
+out_dir = "./dist"
+
+before-each-package-command = """
+robius-packaging-commands before-each-package \
+    --binary-name robrix \
+    --path-to-binary ../../target/release/robrix
+"""
+
+resources = [
+    { src = "./dist/resources/makepad_widgets", target = "makepad_widgets" },
+    { src = "./dist/resources/makepad_fonts_chinese_bold", target = "makepad_fonts_chinese_bold" },
+    { src = "./dist/resources/makepad_fonts_chinese_bold_2", target = "makepad_fonts_chinese_bold_2" },
+    { src = "./dist/resources/makepad_fonts_chinese_regular", target = "makepad_fonts_chinese_regular" },
+    { src = "./dist/resources/makepad_fonts_chinese_regular_2", target = "makepad_fonts_chinese_regular_2" },
+    { src = "./dist/resources/makepad_fonts_emoji", target = "makepad_fonts_emoji" },
+    { src = "./dist/resources/robrix", target = "robrix" },
+]
+```
+
 This program should be invoked by `cargo-packager`'s "before-package" and "before-each-package" hooks,
 which you must specify in your `Cargo.toml` file under the `[package.metadata.packager]` section.
+
+It uses the current working directory as the app root for `./resources` and `./dist`,
+while `--path-to-binary` is used to locate the target directory (useful in workspaces).
 
 > [!IMPORTANT]
 > You *must* build in release mode (using `cargo packager --release`).
@@ -77,7 +106,7 @@ cargo +stable install --force --locked cargo-packager
 > [!IMPORTANT]
 > For Makepad apps using Makepad versions *before* v1.0, install `robius-packaging-commands` `--version 0.1`.
 >
-> For Makepad apps using Makepad versions *after* v1.0, install `robius-packaging-commands` `--version 0.2`.
+> For Makepad apps using Makepad versions *after* v1.0, install `robius-packaging-commands` `--version ^0.2`.
 
 ```sh
 # From crates.io
@@ -95,9 +124,9 @@ cargo packager --release ## --verbose is optional
 
 ## More info
 
-This program must be run from the root of the project directory,
-which is also where the `cargo-packager` command must be invoked from,
-so that shouldn't present any problems.
+This program no longer requires the workspace root as the working directory.
+It uses the current working directory for app resources (`./resources`) and build output (`./dist`),
+and uses `--path-to-binary` to locate the target directory (e.g., a workspace `target/release`).
 
 This program runs in two modes, one for each kind of before-packaging step in cargo-packager:
 1. `before-packaging`: specifies that the `before-packaging-command` is being run by cargo-packager, which gets executed only *once* before cargo-packager generates any package bundles.

--- a/src/makepad.rs
+++ b/src/makepad.rs
@@ -49,8 +49,8 @@ pub(crate) fn is_makepad_app() -> bool {
     })
 }
 
-pub(crate) fn get_makepad_resources_paths() -> HashMap<String, PathBuf> {
-    let paths_dir = PathBuf::from("target/release/");
+pub(crate) fn get_makepad_resources_paths(target_dir: &Path) -> HashMap<String, PathBuf> {
+    let paths_dir = target_dir.to_path_buf();
     fs::read_dir(&paths_dir)
         .into_iter()
         .flatten()
@@ -81,16 +81,16 @@ pub(crate) fn get_makepad_resources_paths() -> HashMap<String, PathBuf> {
 /// This uses `cargo-metadata` to determine the location of the `makepad-widgets` crate,
 /// and then copies the `resources` directory from that crate to a makepad-specific subdirectory
 /// of the given `dist_resources_dir` path, which is currently `./dist/resources/makepad_widgets/`.
-pub(crate) fn copy_makepad_resources<P>(dist_resources_dir: P) -> std::io::Result<()>
+pub(crate) fn copy_makepad_resources<P>(dist_resources_dir: P, target_dir: &Path) -> std::io::Result<()>
 where
     P: AsRef<Path>
 {
-    let makepad_resources_paths = get_makepad_resources_paths();
+    let makepad_resources_paths = get_makepad_resources_paths(target_dir);
     if makepad_resources_paths.is_empty() {
         // This situation can happen if the user use local Makepad repository and deletes the all `makepad-*.path` files.
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "Missing resource paths: no `.path` files found in the Makepad build directory (./target/release/)",
+            format!("Missing resource paths: no `.path` files found in the Makepad build directory ({})", target_dir.display()),
         ));
     }
     println!("Copying Makepad resources...");


### PR DESCRIPTION
## PR Content

- In workspace setups where the app crate isn’t at the workspace root, ./resources and ./dist should still be based on the current working directory.
- The target directory should be derived from --path-to-binary instead of being fixed to ./target/release.
- Update to v0.2.1